### PR TITLE
skip guard(:if/:unless) conditions

### DIFF
--- a/lib/state_machine/event.rb
+++ b/lib/state_machine/event.rb
@@ -186,17 +186,17 @@ module StateMachine
     # on the current state of the given object.
     # 
     # If the event can't be fired, then this will return false, otherwise true.
-    def can_fire?(object)
-      !transition_for(object).nil?
+    def can_fire?(object, *args)
+      !transition_for(object, {}, *args).nil?
     end
     
     # Finds and builds the next transition that can be performed on the given
     # object.  If no transitions can be made, then this will return nil.
-    def transition_for(object, requirements = {})
+    def transition_for(object, requirements = {}, *args)
       requirements[:from] = machine.states.match!(object).name unless custom_from_state = requirements.include?(:from)
       
       guards.each do |guard|
-        if match = guard.match(object, requirements)
+        if match = guard.match(object, requirements, *args)
           # Guard allows for the transition to occur
           from = requirements[:from]
           to = match[:to].values.empty? ? from : match[:to].values.first
@@ -267,8 +267,8 @@ module StateMachine
       # the current event
       def add_actions
         # Checks whether the event can be fired on the current object
-        machine.define_instance_method("can_#{qualified_name}?") do |machine, object|
-          machine.event(name).can_fire?(object)
+        machine.define_instance_method("can_#{qualified_name}?") do |machine, object, *args|
+          machine.event(name).can_fire?(object, *args)
         end
         
         # Gets the next transition that would be performed if the event were

--- a/lib/state_machine/guard.rb
+++ b/lib/state_machine/guard.rb
@@ -107,14 +107,22 @@ module StateMachine
     # * <tt>:on</tt> - One or more events that fired the transition.  If none
     #   are specified, then this will always match.
     # 
+    # In order to skip :if/:unless conditions, pass <tt>false</tt> in *args.
+    #
     # == Examples
     # 
     #   guard = StateMachine::Guard.new(:parked => :idling, :on => :ignite)
     #   
     #   guard.match(object, :on => :ignite) # => {:to => ..., :from => ..., :on => ...}
     #   guard.match(object, :on => :park)   # => nil
-    def match(object, query = {})
-      if (match = match_query(query)) && matches_conditions?(object)
+    #
+    #
+    # # Skip :if/:unless conditions
+    # guard.match(object, {:on => :ignite}, false) # => {:to => ..., :from => ..., :on => ...}
+    
+    def match(object, query = {}, *args)
+      match_condition = args.empty? ? true : args.pop
+      if (match = match_query(query)) && (match_condition ? matches_conditions?(object) : true)
         match
       end
     end

--- a/lib/state_machine/guard.rb
+++ b/lib/state_machine/guard.rb
@@ -121,8 +121,7 @@ module StateMachine
     # guard.match(object, {:on => :ignite}, :skip_conditions => false) # => {:to => ..., :from => ..., :on => ...}
     
     def match(object, query = {}, *args)
-      options = args.extract_options! unless args.empty?
-      options ||= {}
+      options = args.last.is_a?(Hash) ? args.pop : {}
       options[:skip_conditions] ||= false      
       if (match = match_query(query)) && (options[:skip_conditions] ? true : matches_conditions?(object))
         match

--- a/lib/state_machine/guard.rb
+++ b/lib/state_machine/guard.rb
@@ -107,7 +107,7 @@ module StateMachine
     # * <tt>:on</tt> - One or more events that fired the transition.  If none
     #   are specified, then this will always match.
     # 
-    # In order to skip :if/:unless conditions, pass <tt>false</tt> in *args.
+    # In order to skip :if/:unless conditions, pass <tt>:skip_conditions => false</tt> in *args.
     #
     # == Examples
     # 
@@ -118,11 +118,13 @@ module StateMachine
     #
     #
     # # Skip :if/:unless conditions
-    # guard.match(object, {:on => :ignite}, false) # => {:to => ..., :from => ..., :on => ...}
+    # guard.match(object, {:on => :ignite}, :skip_conditions => false) # => {:to => ..., :from => ..., :on => ...}
     
     def match(object, query = {}, *args)
-      match_condition = args.empty? ? true : args.pop
-      if (match = match_query(query)) && (match_condition ? matches_conditions?(object) : true)
+      options = args.extract_options! unless args.empty?
+      options ||= {}
+      options[:skip_conditions] ||= false      
+      if (match = match_query(query)) && (options[:skip_conditions] ? true : matches_conditions?(object))
         match
       end
     end

--- a/test/functional/state_machine_test.rb
+++ b/test/functional/state_machine_test.rb
@@ -285,7 +285,7 @@ class VehicleUnsavedTest < Test::Unit::TestCase
     assert !@vehicle.stalled?
   end
   
-  def test_should_not_be_able_to_park
+  def test_should_not_be_able_to_park    
     assert !@vehicle.can_park?
   end
   
@@ -641,6 +641,16 @@ class VehicleStalledTest < Test::Unit::TestCase
     assert @vehicle.stalled?
   end
   
+  def test_should_not_be_able_to_repair
+    @vehicle.auto_shop.fix_vehicle
+    assert !@vehicle.can_repair?
+  end
+
+  def test_should_be_able_to_repair_if_skip_conditions
+    @vehicle.auto_shop.fix_vehicle
+    assert @vehicle.can_repair?(:skip_conditions => true)
+  end  
+
   def test_should_be_towed
     assert @vehicle.auto_shop.busy?
     assert_equal 1, @vehicle.auto_shop.num_customers

--- a/test/unit/guard_test.rb
+++ b/test/unit/guard_test.rb
@@ -639,6 +639,11 @@ class GuardWithIfConditionalTest < Test::Unit::TestCase
     guard = StateMachine::Guard.new(:if => lambda {false})
     assert_nil guard.match(@object)
   end
+
+  def test_should_match_if_false_and_skip_conditions
+    guard = StateMachine::Guard.new(:if => lambda {false})
+    assert guard.match(@object, {}, :skip_conditions => true)
+  end
 end
 
 class GuardWithMultipleIfConditionalsTest < Test::Unit::TestCase
@@ -658,6 +663,14 @@ class GuardWithMultipleIfConditionalsTest < Test::Unit::TestCase
     guard = StateMachine::Guard.new(:if => [lambda {false}, lambda {true}])
     assert !guard.match(@object)
   end
+
+  def test_should_match_if_any_are_false_and_skip_conditions
+    guard = StateMachine::Guard.new(:if => [lambda {true}, lambda {false}])
+    assert guard.match(@object, {}, :skip_conditions => true)
+
+    guard = StateMachine::Guard.new(:if => [lambda {false}, lambda {true}])
+    assert guard.match(@object, {}, :skip_conditions => true)
+  end	
 end
 
 class GuardWithUnlessConditionalTest < Test::Unit::TestCase
@@ -684,6 +697,11 @@ class GuardWithUnlessConditionalTest < Test::Unit::TestCase
     guard = StateMachine::Guard.new(:unless => lambda {true})
     assert_nil guard.match(@object)
   end
+
+  def test_should_match_if_false_and_skip_conditions
+    guard = StateMachine::Guard.new(:unless => lambda {true})
+    assert guard.match(@object, {}, :skip_conditions => true)
+  end  
 end
 
 class GuardWithMultipleUnlessConditionalsTest < Test::Unit::TestCase
@@ -703,6 +721,14 @@ class GuardWithMultipleUnlessConditionalsTest < Test::Unit::TestCase
     guard = StateMachine::Guard.new(:unless => [lambda {false}, lambda {true}])
     assert !guard.match(@object)
   end
+
+  def test_should_match_if_any_are_false_and_skip_conditions
+    guard = StateMachine::Guard.new(:unless => [lambda {true}, lambda {false}])
+    assert guard.match(@object, {}, :skip_conditions => true)
+
+    guard = StateMachine::Guard.new(:unless => [lambda {false}, lambda {true}])
+    assert guard.match(@object, {}, :skip_conditions => true)
+  end  
 end
 
 class GuardWithConflictingConditionalsTest < Test::Unit::TestCase


### PR DESCRIPTION
Bypass :if/:unless conditions in can_*? methods. For example

 event :repair do

   transition :stalled => :parked, :if => :auto_shop_busy?

 end

@vehicle.state? # =>  'stalled'

@vehicle.can_repair? # => false

@vehicle.can_repair?(:skip_conditions => true) # => true

thx.
