### PR TITLE
Fix Rails 3.1 Depreciation Warning

### DIFF
--- a/lib/state_machine/initializers/rails.rb
+++ b/lib/state_machine/initializers/rails.rb
@@ -12,8 +12,7 @@ if defined?(Rails)
         load 'tasks/state_machine.rb'
       end
     end
-    
-    StateMachine::RailsEngine.paths.config.locales = locale_paths
+    StateMachine::RailsEngine.paths["config/locales"] = locale_paths
   elsif defined?(I18n)
     # Rails 2.x
     I18n.load_path.unshift(*locale_paths)


### PR DESCRIPTION
DEPRECATION WARNING: config.paths.app.controller API is deprecated in favor of config.paths["app/controller"] API. (called from <top (required)> at /Users/burke/.rvm/gems/ruby-1.9.2-p180@core/gems/state_machine-1.0.0/lib/state_machine/initializers/rails.rb:16)
