### PR TITLE
Automatically map string scope parameters to symbols

### DIFF
--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -1786,7 +1786,7 @@ module StateMachine
       # Generates the results for the given scope based on one or more states to
       # filter by
       def run_scope(scope, machine, klass, states)
-        values = states.flatten.map {|state| machine.states.fetch(state).value}
+        values = states.flatten.compact.map {|state| machine.states.fetch(state.to_sym).value}
         scope.call(klass, values)
       end
       

--- a/test/unit/integrations/active_record_test.rb
+++ b/test/unit/integrations/active_record_test.rb
@@ -1708,6 +1708,7 @@ module ActiveRecordTest
         idling = @model.create :state => 'idling'
         
         assert_equal [parked], @model.with_state(:parked).find(:all)
+        assert_equal [parked], @model.with_state('parked').find(:all)
       end
       
       def test_should_create_plural_with_scope
@@ -1719,6 +1720,7 @@ module ActiveRecordTest
         idling = @model.create :state => 'idling'
         
         assert_equal [parked, idling], @model.with_states(:parked, :idling).find(:all)
+        assert_equal [parked, idling], @model.with_state('parked', 'idling').find(:all)
       end
       
       def test_should_create_singular_without_scope
@@ -1730,6 +1732,7 @@ module ActiveRecordTest
         idling = @model.create :state => 'idling'
         
         assert_equal [parked], @model.without_state(:idling).find(:all)
+        assert_equal [parked], @model.without_state('idling').find(:all)
       end
       
       def test_should_create_plural_without_scope
@@ -1742,6 +1745,7 @@ module ActiveRecordTest
         first_gear = @model.create :state => 'first_gear'
         
         assert_equal [parked, idling], @model.without_states(:first_gear).find(:all)
+        assert_equal [parked, idling], @model.without_states('first_gear').find(:all)
       end
       
       def test_should_allow_chaining_scopes
@@ -1749,6 +1753,7 @@ module ActiveRecordTest
         idling = @model.create :state => 'idling'
         
         assert_equal [idling], @model.without_state(:parked).with_state(:idling).find(:all)
+        assert_equal [idling], @model.without_state('parked').with_state('idling').find(:all)
       end
     end
     

--- a/test/unit/integrations/data_mapper_test.rb
+++ b/test/unit/integrations/data_mapper_test.rb
@@ -1785,6 +1785,7 @@ module DataMapperTest
       idling = @resource.create :state => 'idling'
       
       assert_equal [parked], @resource.with_state(:parked)
+      assert_equal [parked], @resource.with_state('parked')
     end
     
     def test_should_create_plural_with_scope
@@ -1796,6 +1797,7 @@ module DataMapperTest
       idling = @resource.create :state => 'idling'
       
       assert_equal [parked, idling], @resource.with_states(:parked, :idling)
+       assert_equal [parked, idling], @resource.with_states('parked', 'idling')
     end
     
     def test_should_create_singular_without_scope
@@ -1807,6 +1809,7 @@ module DataMapperTest
       idling = @resource.create :state => 'idling'
       
       assert_equal [parked], @resource.without_state(:idling)
+      assert_equal [parked], @resource.without_state('idling')
     end
     
     def test_should_create_plural_without_scope
@@ -1819,6 +1822,7 @@ module DataMapperTest
       first_gear = @resource.create :state => 'first_gear'
       
       assert_equal [parked, idling], @resource.without_states(:first_gear)
+      assert_equal [parked, idling], @resource.without_states('first_gear')
     end
     
     def test_should_allow_chaining_scopes
@@ -1826,6 +1830,7 @@ module DataMapperTest
       idling = @resource.create :state => 'idling'
       
       assert_equal [idling], @resource.without_state(:parked).with_state(:idling)
+      assert_equal [idling], @resource.without_state('parked').with_state('idling')
     end
   end
   

--- a/test/unit/integrations/mongo_mapper_test.rb
+++ b/test/unit/integrations/mongo_mapper_test.rb
@@ -1360,6 +1360,7 @@ module MongoMapperTest
       idling = @model.create :state => 'idling'
       
       assert_equal [parked], @model.with_state(:parked).to_a
+      assert_equal [parked], @model.with_state('parked').to_a
     end
     
     def test_should_create_plural_with_scope
@@ -1371,6 +1372,7 @@ module MongoMapperTest
       idling = @model.create :state => 'idling'
       
       assert_equal [parked, idling], @model.with_states(:parked, :idling).to_a
+      assert_equal [parked, idling], @model.with_states('parked', 'idling').to_a
     end
     
     def test_should_create_singular_without_scope
@@ -1382,6 +1384,7 @@ module MongoMapperTest
       idling = @model.create :state => 'idling'
       
       assert_equal [parked], @model.without_state(:idling).to_a
+      assert_equal [parked], @model.without_state('idling').to_a
     end
     
     def test_should_create_plural_without_scope
@@ -1394,6 +1397,7 @@ module MongoMapperTest
       first_gear = @model.create :state => 'first_gear'
       
       assert_equal [parked, idling], @model.without_states(:first_gear).to_a
+      assert_equal [parked, idling], @model.without_states('first_gear').to_a
     end
     
     if defined?(MongoMapper::Version) && MongoMapper::Version >= '0.8.0'
@@ -1402,6 +1406,7 @@ module MongoMapperTest
         idling = @model.create :state => 'idling'
         
         assert_equal [idling], @model.without_state(:parked).with_state(:idling).all
+        assert_equal [idling], @model.without_state('parked').with_state('idling').all
       end
     end
   end

--- a/test/unit/integrations/mongoid_test.rb
+++ b/test/unit/integrations/mongoid_test.rb
@@ -1316,6 +1316,7 @@ module MongoidTest
       idling = @model.create :state => 'idling'
       
       assert_equal [parked], @model.with_state(:parked).to_a
+      assert_equal [parked], @model.with_state('parked').to_a
     end
     
     def test_should_create_plural_with_scope
@@ -1327,6 +1328,7 @@ module MongoidTest
       idling = @model.create :state => 'idling'
       
       assert_equal [parked, idling], @model.with_states(:parked, :idling).to_a
+      assert_equal [parked, idling], @model.with_state('parked', 'idling').to_a
     end
     
     def test_should_create_singular_without_scope
@@ -1338,6 +1340,7 @@ module MongoidTest
       idling = @model.create :state => 'idling'
       
       assert_equal [parked], @model.without_state(:idling).to_a
+      assert_equal [parked], @model.without_state('idling').to_a
     end
     
     def test_should_create_plural_without_scope
@@ -1350,6 +1353,7 @@ module MongoidTest
       first_gear = @model.create :state => 'first_gear'
       
       assert_equal [parked, idling], @model.without_states(:first_gear).to_a
+      assert_equal [parked, idling], @model.without_states('first_gear').to_a
     end
     
     def test_should_allow_chaining_scopes
@@ -1357,6 +1361,7 @@ module MongoidTest
       idling = @model.create :state => 'idling'
       
       assert_equal [idling], @model.without_state(:parked).with_state(:idling).all
+      assert_equal [idling], @model.without_state('parked').with_state('idling').to_a
     end
   end
   


### PR DESCRIPTION
Allow string states in scopes (useful when accepting state name from forms)

Saves some typecasting when doing per state filtering using checkboxes or selects

Tested core and all integrations with current gems

Two test are failing here (rake test INTEGRATION=sequel VERSION=3.25.0) but it's not my fault 
