### PR TITLE
Alternate syntax for defining state machine by state

### DIFF
--- a/lib/state_machine/alternate_machine.rb
+++ b/lib/state_machine/alternate_machine.rb
@@ -33,6 +33,9 @@ module StateMachine
   class AlternateMachine
     include MatcherHelpers
 
+    class InvalidEventError < StandardError
+    end
+
     def initialize(&block)
       @queued_sends = []
       instance_eval(&block) if block_given?
@@ -41,10 +44,13 @@ module StateMachine
     def state(*args, &block)
       @from_state = args.first
       instance_eval(&block) if block_given?
+    ensure
+      @from_state = nil
     end
 
     def event(event_name, options = {})
       to_state = options.delete(:to)
+      raise InvalidEventError.new("event must be called within a state definition") unless @from_state
       @queued_sends << [event_name, @from_state, to_state, options]
     end
 

--- a/lib/state_machine/alternate_machine.rb
+++ b/lib/state_machine/alternate_machine.rb
@@ -1,0 +1,73 @@
+module StateMachine
+  # Provides an alternate syntax for defining state machines
+  #
+  # For example,
+  #
+  #   class Vehicle
+  #     state_machine :initial => :parked, :action => :save, :syntax => :alternate do
+  #       state :parked do
+  #         event :ignite, :to => :idling, :if => :have_keys?
+  #       end
+  #
+  #       state :idling do
+  #         event :park, :to => :parked, :unless => :no_spots?
+  #       end
+  #     end
+  #   end
+  #
+  # Instead of,
+  #
+  #   class Vehicle
+  #     state_machine :initial => :parked, :action => :save do
+  #       event :ignite do
+  #         transition :parked => :idling, :if => :have_keys?
+  #       end
+  #
+  #       event :park do
+  #         transition :idling => :parked, :unless => :no_spots?
+  #       end
+  #     end
+  #   end
+  #
+  # Also supports usage of :any, :all, and :same as valid states.
+  class AlternateMachine
+    include MatcherHelpers
+
+    def initialize(&block)
+      @queued_sends = []
+      instance_eval(&block) if block_given?
+    end
+
+    def state(*args, &block)
+      @from_state = args.first
+      instance_eval(&block) if block_given?
+    end
+
+    def event(event_name, options = {})
+      to_state = options.delete(:to)
+      @queued_sends << [event_name, @from_state, to_state, options]
+    end
+
+    def to_state_machine
+      queued_sends = @queued_sends
+      lambda {
+        queued_sends.each do |args|
+          case args.length
+          when 2 # method_missing
+            args, block = args
+            send(*args, &block)
+          when 4 # event transition
+            event_name, from, to, options = args
+            event event_name do
+              transition options.merge(from => to)
+            end
+          end
+        end
+      }
+    end
+
+    def method_missing(*args, &block)
+      @queued_sends << [args, block]
+    end
+  end
+end

--- a/lib/state_machine/branch.rb
+++ b/lib/state_machine/branch.rb
@@ -160,7 +160,10 @@ module StateMachine
         # Generate an edge between each from and to state
         from_states.each do |from_state|
           from_state = from_state ? from_state.to_s : 'nil'
-          edges << graph.add_edge(from_state, loopback ? from_state : to_state, :label => event.to_s)
+          label = event.to_s
+          label += " (#{if_condition})" if if_condition
+          label += " (not #{unless_condition})" if unless_condition
+          edges << graph.add_edge(from_state, loopback ? from_state : to_state, :label => label)
         end
         
         edges

--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -328,7 +328,7 @@ module StateMachine
           end
           
           # Evaluate DSL
-          machine.evaluate_with_syntax(&block) if block_given?
+          machine.evaluate_with_syntax(options[:syntax], &block) if block_given?
         else
           # No existing machine: create a new one
           machine = new(owner_class, name, options, &block)
@@ -461,7 +461,7 @@ module StateMachine
       after_initialize
       
       # Evaluate DSL
-      evaluate_with_syntax(&block) if block_given?
+      evaluate_with_syntax(@syntax, &block) if block_given?
     end
     
     # Creates a copy of this machine in addition to copies of each associated
@@ -477,8 +477,8 @@ module StateMachine
       @callbacks = {:before => @callbacks[:before].dup, :after => @callbacks[:after].dup, :failure => @callbacks[:failure].dup}
     end
     
-    def evaluate_with_syntax(&block)
-      if @syntax == :alternate
+    def evaluate_with_syntax(syntax, &block)
+      if syntax == :alternate
         instance_eval(&alternate_syntax_eval(&block))
       else
         instance_eval(&block)

--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -328,13 +328,7 @@ module StateMachine
           end
           
           # Evaluate DSL
-          if block_given?
-            if options[:syntax] == :alternate
-              machine.instance_eval(&machine.alternate_syntax_eval(&block))
-            else
-              machine.instance_eval(&block)
-            end
-          end
+          machine.evaluate_with_syntax(&block) if block_given?
         else
           # No existing machine: create a new one
           machine = new(owner_class, name, options, &block)
@@ -467,13 +461,7 @@ module StateMachine
       after_initialize
       
       # Evaluate DSL
-      if block_given?
-        if @syntax == :alternate
-          instance_eval(&alternate_syntax_eval(&block))
-        else
-          instance_eval(&block)
-        end
-      end
+      evaluate_with_syntax(&block) if block_given?
     end
     
     # Creates a copy of this machine in addition to copies of each associated
@@ -487,6 +475,14 @@ module StateMachine
       @states = @states.dup
       @states.machine = self
       @callbacks = {:before => @callbacks[:before].dup, :after => @callbacks[:after].dup, :failure => @callbacks[:failure].dup}
+    end
+    
+    def evaluate_with_syntax(&block)
+      if @syntax == :alternate
+        instance_eval(&alternate_syntax_eval(&block))
+      else
+        instance_eval(&block)
+      end
     end
     
     def alternate_syntax_eval(&block)

--- a/test/functional/alternate_state_machine_test.rb
+++ b/test/functional/alternate_state_machine_test.rb
@@ -78,6 +78,19 @@ class AlternateAutoShopAvailableTest < Test::Unit::TestCase
     assert @auto_shop.close
     assert @auto_shop.closed?
   end
+
+  def test_should_not_allow_event_outside_state
+    assert_raises(StateMachine::AlternateMachine::InvalidEventError) do
+      AlternateAutoShop.class_eval do
+        state_machine :initial => :available, :syntax => :alternate do
+          state any do
+          end
+
+          event :not_work, :to => :never
+        end
+      end
+    end
+  end
 end
 
 class AlternateAutoShopBusyTest < Test::Unit::TestCase

--- a/test/functional/alternate_state_machine_test.rb
+++ b/test/functional/alternate_state_machine_test.rb
@@ -1,0 +1,109 @@
+require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
+
+class AlternateAutoShop
+  attr_accessor :num_customers
+  attr_accessor :weekend
+  attr_accessor :have_parts
+
+  def initialize
+    @num_customers = 0
+    @weekend = false
+    @have_parts = true
+    super
+  end
+
+  state_machine :initial => :available, :syntax => :alternate do
+    after_transition :available => any, :do => :increment_customers
+    after_transition :busy => any, :do => :decrement_customers
+
+    state :available do
+      event :tow_vehicle, :to => :busy, :unless => :weekend?
+    end
+
+    state :busy do
+      event :fix_vehicle, :to => :available, :if => :have_parts?
+    end
+  end
+
+  def weekend?
+    !!weekend
+  end
+
+  def have_parts?
+    !!have_parts
+  end
+
+  # Increments the number of customers in service
+  def increment_customers
+    self.num_customers += 1
+  end
+
+  # Decrements the number of customers in service
+  def decrement_customers
+    self.num_customers -= 1
+  end
+end
+
+class AlternateAutoShopAvailableTest < Test::Unit::TestCase
+  def setup
+    @auto_shop = AlternateAutoShop.new
+  end
+
+  def test_should_be_in_available_state
+    assert_equal 'available', @auto_shop.state
+  end
+
+  def test_should_allow_tow_vehicle
+    assert @auto_shop.tow_vehicle
+  end
+
+  def test_should_allow_tow_vehicle_on_weekends
+    @auto_shop.weekend = true
+    assert !@auto_shop.tow_vehicle
+  end
+
+  def test_should_not_allow_fix_vehicle
+    assert !@auto_shop.fix_vehicle
+  end
+
+  def test_should_append_to_machine
+    AlternateAutoShop.class_eval do
+      state_machine :initial => :available, :syntax => :alternate do
+        state any do
+          event :close, :to => :closed
+        end
+      end
+    end
+
+    assert @auto_shop.close
+    assert @auto_shop.closed?
+  end
+end
+
+class AlternateAutoShopBusyTest < Test::Unit::TestCase
+  def setup
+    @auto_shop = AlternateAutoShop.new
+    @auto_shop.tow_vehicle
+  end
+
+  def test_should_be_in_busy_state
+    assert_equal 'busy', @auto_shop.state
+  end
+
+  def test_should_have_incremented_number_of_customers
+    assert_equal 1, @auto_shop.num_customers
+  end
+
+  def test_should_not_allow_tow_vehicle
+    assert !@auto_shop.tow_vehicle
+  end
+
+  def test_should_allow_fix_vehicle
+    assert @auto_shop.fix_vehicle
+  end
+
+  def test_should_not_allow_fix_vehicle_if_dont_have_parts
+    @auto_shop.have_parts = false
+    assert !@auto_shop.fix_vehicle
+  end
+end

--- a/test/functional/alternate_state_machine_test.rb
+++ b/test/functional/alternate_state_machine_test.rb
@@ -79,6 +79,19 @@ class AlternateAutoShopAvailableTest < Test::Unit::TestCase
     assert @auto_shop.closed?
   end
 
+  def test_should_append_to_machine_in_default_syntax
+    AlternateAutoShop.class_eval do
+      state_machine :initial => :available do
+        event :restart do
+          transition any => :restarted
+        end
+      end
+    end
+
+    assert @auto_shop.restart
+    assert @auto_shop.restarted?
+  end
+
   def test_should_not_allow_event_outside_state
     assert_raises(StateMachine::AlternateMachine::InvalidEventError) do
       AlternateAutoShop.class_eval do

--- a/test/unit/branch_test.rb
+++ b/test/unit/branch_test.rb
@@ -885,6 +885,38 @@ begin
       assert_equal 'nil', @edges.first.instance_variable_get('@xNodeTwo')
     end
   end
+  
+  class BranchDrawingWithIfConditionTest < Test::Unit::TestCase
+    def setup
+      @machine = StateMachine::Machine.new(Class.new)
+      
+      graph = GraphViz.new('G')
+      graph.add_node('parked')
+      
+      @branch = StateMachine::Branch.new(:from => :idling, :to => nil, :if => :have_keys?)
+      @edges = @branch.draw(graph, :park, [nil, :idling])
+    end
+    
+    def test_should_use_event_name_and_if_condition_as_label
+      assert_equal 'park (have_keys?)', @edges.first['label'].to_s.gsub('"', '')
+    end
+  end
+  
+  class BranchDrawingWithUnlessConditionTest < Test::Unit::TestCase
+    def setup
+      @machine = StateMachine::Machine.new(Class.new)
+      
+      graph = GraphViz.new('G')
+      graph.add_node('parked')
+      
+      @branch = StateMachine::Branch.new(:from => :idling, :to => nil, :unless => :missing_keys?)
+      @edges = @branch.draw(graph, :park, [nil, :idling])
+    end
+    
+    def test_should_use_event_name_and_unless_condition_as_label
+      assert_equal 'park (not missing_keys?)', @edges.first['label'].to_s.gsub('"', '')
+    end
+  end
 rescue LoadError
   $stderr.puts 'Skipping GraphViz StateMachine::Branch tests. `gem install ruby-graphviz` >= v0.9.0 and try again.'
 end

--- a/test/unit/machine_test.rb
+++ b/test/unit/machine_test.rb
@@ -1,5 +1,9 @@
 require File.expand_path(File.dirname(__FILE__) + '/../test_helper')
 
+class Sample
+  
+end
+
 class MachineByDefaultTest < Test::Unit::TestCase
   def setup
     @klass = Class.new
@@ -954,6 +958,80 @@ class MachineAfterBeingCopiedTest < Test::Unit::TestCase
     @machine.after_failure(lambda {})
     
     @copied_machine = @machine.clone
+  end
+  
+  def test_should_not_have_the_same_collection_of_states
+    assert_not_same @copied_machine.states, @machine.states
+  end
+  
+  def test_should_copy_each_state
+    assert_not_same @copied_machine.states[:parked], @machine.states[:parked]
+  end
+  
+  def test_should_update_machine_for_each_state
+    assert_equal @copied_machine, @copied_machine.states[:parked].machine
+  end
+  
+  def test_should_not_update_machine_for_original_state
+    assert_equal @machine, @machine.states[:parked].machine
+  end
+  
+  def test_should_not_have_the_same_collection_of_events
+    assert_not_same @copied_machine.events, @machine.events
+  end
+  
+  def test_should_copy_each_event
+    assert_not_same @copied_machine.events[:ignite], @machine.events[:ignite]
+  end
+  
+  def test_should_update_machine_for_each_event
+    assert_equal @copied_machine, @copied_machine.events[:ignite].machine
+  end
+  
+  def test_should_not_update_machine_for_original_event
+    assert_equal @machine, @machine.events[:ignite].machine
+  end
+  
+  def test_should_not_have_the_same_callbacks
+    assert_not_same @copied_machine.callbacks, @machine.callbacks
+  end
+  
+  def test_should_not_have_the_same_before_callbacks
+    assert_not_same @copied_machine.callbacks[:before], @machine.callbacks[:before]
+  end
+  
+  def test_should_not_have_the_same_after_callbacks
+    assert_not_same @copied_machine.callbacks[:after], @machine.callbacks[:after]
+  end
+  
+  def test_should_not_have_the_same_failure_callbacks
+    assert_not_same @copied_machine.callbacks[:failure], @machine.callbacks[:failure]
+  end
+end
+
+class MachineAfterBeingDuplicatedTest < Test::Unit::TestCase
+  def setup
+    @machine = StateMachine::Machine.new(Class.new, :state, :initial => :parked)
+    @machine.event(:ignite) {}
+    @machine.before_transition(lambda {})
+    @machine.after_transition(lambda {})
+    @machine.around_transition(lambda {})
+    @machine.after_failure(lambda {})
+    
+    @new_class = Class.new
+    
+    @copied_machine = @machine.duplicate_to(@new_class)
+  end
+  
+  def test_should_copy_each_event_and_add_actions
+    @new_instance = @new_class.new
+    assert @new_instance.respond_to?(:ignite)
+    assert @new_instance.respond_to?(:ignite!)
+  end
+  
+  def test_should_copy_each_event_and_add_predicate
+    @new_instance = @new_class.new
+    assert @new_instance.respond_to?(:parked?)
   end
   
   def test_should_not_have_the_same_collection_of_states


### PR DESCRIPTION
Provides a syntax more suitable for defining workflows (similar to [the workflow gem](http://github.com/geekq/workflow)). It may be useful to provide this so users of `state_machine` can choose the syntax that suits their need without having to switch to another gem.

Instead of,

```
event :park do
  transition :idling => :parked, :if => :emergency_brake?
end
```

Do,

```
state :idling do
  event :park, :to => :parked, :if => :emergency_brake?
end
```

You can mix and match syntaxes like,

```
state_machine :state, :initial => :parked, :syntax => :alternate do
  state ... do
  end
end

state_machine :state, :initial => :parked do
  event ... do
  end
end
```

and they will augment the same state machine. Things like `after_transition` and `before_transition` apply the same in both syntaxes.

I've also added :if and :unless conditions to graphviz drawing so it's obvious why one branch is being taken over another.

Thanks!
