### PR TITLE
Fix datamapper depreciation and internals change.

### DIFF
--- a/lib/state_machine/integrations/data_mapper.rb
+++ b/lib/state_machine/integrations/data_mapper.rb
@@ -398,9 +398,9 @@ module StateMachine
         # Marks the object's state as dirty so that the record will be saved
         # even if no actual modifications have been made to the data
         def mark_dirty(object, value)
-          object.persisted_state = ::DataMapper::Resource::State::Dirty.new(object) if object.persisted_state.is_a?(::DataMapper::Resource::State::Clean)
+          object.peristence_state = ::DataMapper::Resource::PersistenceState::Dirty.new(object) if object.persistence_state.is_a?(::DataMapper::Resource::PersistenceState::Clean)
           property = owner_class.properties[self.attribute]
-          object.persisted_state.original_attributes[property] = value unless object.persisted_state.original_attributes.include?(property)
+          object.persistence_state.original_attributes[property] = value unless object.persistence_state.original_attributes.include?(property)
         end
     end
   end

--- a/lib/state_machine/integrations/data_mapper.rb
+++ b/lib/state_machine/integrations/data_mapper.rb
@@ -398,7 +398,7 @@ module StateMachine
         # Marks the object's state as dirty so that the record will be saved
         # even if no actual modifications have been made to the data
         def mark_dirty(object, value)
-          object.peristence_state = ::DataMapper::Resource::PersistenceState::Dirty.new(object) if object.persistence_state.is_a?(::DataMapper::Resource::PersistenceState::Clean)
+          object.persistence_state = ::DataMapper::Resource::PersistenceState::Dirty.new(object) if object.persistence_state.is_a?(::DataMapper::Resource::PersistenceState::Clean)
           property = owner_class.properties[self.attribute]
           object.persistence_state.original_attributes[property] = value unless object.persistence_state.original_attributes.include?(property)
         end


### PR DESCRIPTION
Naming of DataMapper State internals has changed in current master.

This commit is not compatible with dm-1.1.0, it should not be merged.

This pull request needs additional effort to support dm-1.1.0 and the future dm-1.2.0. 

Feel free to give me information about your favorite way to support both versions. I'll attach a second commit to support both dm-1.1.0 and dm-master.

My idea is:

``` ruby
if DataMapper::VERSION <= '1.1.0'
  def mark_dirty
    old code
  end
else
  def mark_dirty
    new_code
  end
end
```
