### PR TITLE
Removes ruby 1.8.6 from travis ci as it is not supported anymore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 script: "bundle exec rake appraisal:integration test"
 rvm:
-  - 1.8.6
   - 1.8.7
   - 1.9.1
   - 1.9.2


### PR DESCRIPTION
Make state_machine build badge green again :)
