### PR TITLE
Add dependency status image via Gemnasium to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# state_machine [![Build Status](https://secure.travis-ci.org/pluginaweek/state_machine.png "Build Status")](http://travis-ci.org/pluginaweek/state_machine)
+# state_machine [![Build Status](https://secure.travis-ci.org/pluginaweek/state_machine.png "Build Status")](http://travis-ci.org/pluginaweek/state_machine) [![Dependency Status](https://gemnasium.com/pluginaweek/state_machine.png "Dependency Status")](https://gemnasium.com/pluginaweek/state_machine)
 
 *state_machine* adds support for creating state machines for attributes on any
 Ruby class.


### PR DESCRIPTION
The dependency status is an indicator of how up-to-date state_machine's gem dependencies are with the latest versions.
