### PR TITLE
Allowing for dynamically handled method_missing methods (in say a superclass) to be used during conditional transitions..

### DIFF
--- a/lib/state_machine/eval_helpers.rb
+++ b/lib/state_machine/eval_helpers.rb
@@ -52,40 +52,39 @@ module StateMachine
     #   evaluate_method(person, lambda {|person, age| "#{person.name} is #{age}"}, 21, 'male')  # => ArgumentError: wrong number of arguments (3 for 2)
     def evaluate_method(object, method, *args, &block)
       case method
-      when Symbol
-        if method_defined?(method) or private_method_defined?(method) or protected_method_defined?(method)
-          
-          object.method(method).arity == 0 ? object.send(method, &block) : object.send(method, *args, &block)
-        else
-          object.send(method, *args, &block)
-        end
-        
-      when Proc, Method
-        args.unshift(object)
-        arity = method.arity
-        
-        # Procs don't support blocks in < Ruby 1.9, so it's tacked on as an
-        # argument for consistency across versions of Ruby
-        if block_given? && Proc === method && arity != 0
-          if [1, 2].include?(arity)
-            # Force the block to be either the only argument or the 2nd one
-            # after the object (may mean additional arguments get discarded)
-            args = args[0, arity - 1] + [block]
+        when Symbol
+          if (method_defined?(method) || private_method_defined?(method)) && object.method(method).arity == 0
+            object.send(method, &block)
           else
-            # Tack the block to the end of the args
-            args << block
+            object.send(method, *args, &block)
           end
-        else
-          # These method types are only called with 0, 1, or n arguments
-          args = args[0, arity] if [0, 1].include?(arity)
-        end
         
-        method.call(*args, &block)
-      when String
-        eval(method, object.instance_eval {binding}, &block)
-      else
-        raise ArgumentError, 'Methods must be a symbol denoting the method to call, a block to be invoked, or a string to be evaluated'
-      end
+        when Proc, Method
+          args.unshift(object)
+          arity = method.arity
+        
+          # Procs don't support blocks in < Ruby 1.9, so it's tacked on as an
+          # argument for consistency across versions of Ruby
+          if block_given? && Proc === method && arity != 0
+            if [1, 2].include?(arity)
+              # Force the block to be either the only argument or the 2nd one
+              # after the object (may mean additional arguments get discarded)
+              args = args[0, arity - 1] + [block]
+            else
+              # Tack the block to the end of the args
+              args << block
+            end
+          else
+            # These method types are only called with 0, 1, or n arguments
+            args = args[0, arity] if [0, 1].include?(arity)
+          end
+        
+          method.call(*args, &block)
+        when String
+          eval(method, object.instance_eval {binding}, &block)
+        else
+          raise ArgumentError, 'Methods must be a symbol denoting the method to call, a block to be invoked, or a string to be evaluated'
+        end
     end
   end
 end


### PR DESCRIPTION
If we want to do something like the example below.. since the eval_helper checks for `object.method(method)` if input is a symbol, I was getting a NameError.. i.e method missing is not called. Ive tried to handle this transparently.. Please check code commit. Does this make sense? (its my first pull request)

``` ruby
class SomeClassWithStateMachine
  state :state, :initial => :starting do

    event :go_to_race, :if => :ready_for_the_race do
      transition :starting => :ending
    end

    event :go_to_space, :if => :ready_for_space do
      transition :starting => :ending
    end

    state :starting
    state :ending
  end

  def method_missing(m_name, *args, &block)
    if format_check(m_name)
      strategy_name = m_name.to_s.split("_").last
      use_readiness_check_strategy(strategy_name)
    else
      super
    end
  end

  def respond_to_missing?(m_name, private_m)
    format_check(m_name) and private_m
  end

  private

  def use_readiness_check_strategy(strategy_name)

    # Delegate to a strategy object..
    strategy_name.camelize.constantize.new
  end

  def format_check(m_name)
    m_name.to_s.split("ready_for_the_").first.empty? or 
    m_name.to_s.split("ready_for_").first.empty?
  end
end

```
