### PR TITLE
Do not call callbacks when they are disabled

### DIFF
--- a/lib/state_machine/integrations/active_model/observer.rb
+++ b/lib/state_machine/integrations/active_model/observer.rb
@@ -21,7 +21,10 @@ module StateMachine
       module Observer
         def update_with_transition(args)
           observed_method, object, transition = args
-          send(observed_method, object, transition) if respond_to?(observed_method)
+          return unless respond_to?(observed_method)
+          return if disabled_for?(object)
+
+          send(observed_method, object, transition)
         end
       end
     end

--- a/test/unit/integrations/active_model_test.rb
+++ b/test/unit/integrations/active_model_test.rb
@@ -764,6 +764,37 @@ module ActiveModelTest
       @transition.perform
       assert_equal callbacks, instance.notifications
     end
+
+    def test_should_call_no_transition_callbacks_when_observers_disabled
+      callbacks = [
+        :before_ignite_from_parked_to_idling,
+        :before_ignite_from_parked,
+        :before_ignite_to_idling,
+        :before_ignite,
+        :before_transition_state_from_parked_to_idling,
+        :before_transition_state_from_parked,
+        :before_transition_state_to_idling,
+        :before_transition_state,
+        :before_transition
+      ]
+
+      notified = false
+      observer = new_observer(@model) do
+        callbacks.each do |callback|
+          define_method(callback) do |*args|
+            notifications << callback
+          end
+        end
+      end
+
+      instance = observer.instance
+
+      @model.observers.disable observer do
+        @transition.perform
+      end
+
+      assert_equal [], instance.notifications
+    end
     
     def test_should_pass_record_and_transition_to_before_callbacks
       observer = new_observer(@model) do

--- a/test/unit/integrations/active_record_test.rb
+++ b/test/unit/integrations/active_record_test.rb
@@ -1585,7 +1585,38 @@ module ActiveRecordTest
       @transition.perform
       assert_equal callbacks, instance.notifications
     end
-    
+
+    def test_should_call_no_transition_callbacks_when_observers_disabled
+      callbacks = [
+        :before_ignite_from_parked_to_idling,
+        :before_ignite_from_parked,
+        :before_ignite_to_idling,
+        :before_ignite,
+        :before_transition_state_from_parked_to_idling,
+        :before_transition_state_from_parked,
+        :before_transition_state_to_idling,
+        :before_transition_state,
+        :before_transition
+      ]
+
+      notified = false
+      observer = new_observer(@model) do
+        callbacks.each do |callback|
+          define_method(callback) do |*args|
+            notifications << callback
+          end
+        end
+      end
+
+      instance = observer.instance
+
+      @model.observers.disable observer do
+        @transition.perform
+      end
+
+      assert_equal [], instance.notifications
+    end
+
     def test_should_pass_record_and_transition_to_before_callbacks
       observer = new_observer(@model) do
         def before_transition(*args)


### PR DESCRIPTION
Hi,

I've been using state_machine with ActiveRecord and in some instances am using ActiveRecord::Observers.disable to turn off observers (for instance, to isolate certain model behaviors during tests).  state_machine's definition of Observer.update_with_transition does not check for disabled_for? before using the send method to call the callback.

I added test cases to the ActiveModel and ActiveRecord integration tests to test the behavior and changed the update_with_transition method to match the [current implementation in ActiveModel itself](https://github.com/myronmarston/rails/blob/d3c15a1d31d77e44b142c96cb55b654f3552a89d/activemodel/lib/active_model/observing.rb#L229).

Thanks!
-Joe
