### PR TITLE
Adding conditions to the graphviz edge label

### DIFF
--- a/lib/state_machine/branch.rb
+++ b/lib/state_machine/branch.rb
@@ -160,7 +160,12 @@ module StateMachine
         # Generate an edge between each from and to state
         from_states.each do |from_state|
           from_state = from_state ? from_state.to_s : 'nil'
-          edges << graph.add_edge(from_state, loopback ? from_state : to_state, :label => event.to_s)
+
+          label = event.to_s
+          label = "#{label} if #{self.if_condition}" if self.if_condition
+          label = "#{label} unless #{self.unless_condition}" if self.unless_condition
+
+          edges << graph.add_edge(from_state, loopback ? from_state : to_state, :label => label)
         end
         
         edges

--- a/test/unit/branch_test.rb
+++ b/test/unit/branch_test.rb
@@ -790,6 +790,64 @@ begin
       assert_equal 'park', @edges.first['label'].to_s.gsub('"', '')
     end
   end
+
+  class BranchDrawingWithIfConditionTest < Test::Unit::TestCase
+    def setup
+      @machine = StateMachine::Machine.new(Class.new)
+      states = [:parked, :idling]
+
+      graph = GraphViz.new('G')
+      states.each {|state| graph.add_node(state.to_s)}
+
+      @branch = StateMachine::Branch.new(:from => :idling, :to => :parked, :if => :some_condition)
+      @edges = @branch.draw(graph, :park, states)
+    end
+
+    def test_should_create_edges
+      assert_equal 1, @edges.size
+    end
+
+    def test_should_use_from_state_from_start_node
+      assert_equal 'idling', @edges.first.instance_variable_get('@xNodeOne')
+    end
+
+    def test_should_use_to_state_for_end_node
+      assert_equal 'parked', @edges.first.instance_variable_get('@xNodeTwo')
+    end
+
+    def test_should_use_event_name_as_label
+      assert_equal 'park if some_condition', @edges.first['label'].to_s.gsub('"', '')
+    end
+  end
+
+  class BranchDrawingWithUnlessConditionTest < Test::Unit::TestCase
+    def setup
+      @machine = StateMachine::Machine.new(Class.new)
+      states = [:parked, :idling]
+
+      graph = GraphViz.new('G')
+      states.each {|state| graph.add_node(state.to_s)}
+
+      @branch = StateMachine::Branch.new(:from => :idling, :to => :parked, :unless => :some_condition)
+      @edges = @branch.draw(graph, :park, states)
+    end
+
+    def test_should_create_edges
+      assert_equal 1, @edges.size
+    end
+
+    def test_should_use_from_state_from_start_node
+      assert_equal 'idling', @edges.first.instance_variable_get('@xNodeOne')
+    end
+
+    def test_should_use_to_state_for_end_node
+      assert_equal 'parked', @edges.first.instance_variable_get('@xNodeTwo')
+    end
+
+    def test_should_use_event_name_as_label
+      assert_equal 'park unless some_condition', @edges.first['label'].to_s.gsub('"', '')
+    end
+  end
   
   class BranchDrawingWithFromRequirementTest < Test::Unit::TestCase
     def setup


### PR DESCRIPTION
This shows any :if or :unless conditional to the edge in the graphviz output. This is helpful in cases where there are transitions such as:

```
transition :from => :idling, :to => :parked, :if => :some_condition
transition :from => :idling, :to => :other, :unless => :some_condition
```
