### PR TITLE
Link to GraphViz.org fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,7 +914,7 @@ gem 'state_machine', :require => 'state_machine/core'
 ### Generating graphs
 
 This library comes with built-in support for generating di-graphs based on the
-events, states, and transitions defined for a state machine using [GraphViz](http://www.graphviz.org]).
+events, states, and transitions defined for a state machine using [GraphViz](http://www.graphviz.org).
 This requires that both the `ruby-graphviz` gem and graphviz library be
 installed on the system.
 


### PR DESCRIPTION
A minor fix in the README. The current link does not work due to an unneeded closing bracket in the url.
