### PR TITLE
Remove gemspec's dependency on command-line Git

### DIFF
--- a/state_machine.gemspec
+++ b/state_machine.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |s|
   s.description       = "Adds support for creating state machines for attributes on any Ruby class"
   s.summary           = "State machines for attributes"
   s.require_paths     = ["lib"]
-  s.files             = `git ls-files`.split("\n")
-  s.test_files        = `git ls-files -- test/*`.split("\n")
+  s.files             = Dir.glob("**/*").find_all{|f| File.file?(f)}
+  s.test_files        = Dir.glob("test/**/*").find_all{|f| File.file?(f)}
   s.rdoc_options      = %w(--line-numbers --inline-source --title state_machine --main README.md)
   s.extra_rdoc_files  = %w(README.md CHANGELOG.md LICENSE)
   


### PR DESCRIPTION
This is meant to remove the requirement for a "git" binary on the system path. I _think_ the Dir.glob calls are equivalent.
