### PR TITLE
Removed 'invalid' translation from locale specification 

### DIFF
--- a/lib/state_machine/integrations/active_model.rb
+++ b/lib/state_machine/integrations/active_model.rb
@@ -242,7 +242,6 @@ module StateMachine
     #     activemodel:
     #       errors:
     #         messages:
-    #           invalid: "is invalid"
     #           # %{value} = attribute value, %{state} = Human state name
     #           invalid_event: "cannot transition when %{state}"
     #           # %{value} = attribute value, %{event} = Human event name, %{state} = Human current state name
@@ -255,7 +254,7 @@ module StateMachine
     #       errors:
     #         models:
     #           user:
-    #             invalid: "is not valid"
+    #             invalid_event: "is not valid"
     # 
     # In addition to the above, you can also provide translations for the
     # various states / events in each state machine.  Using the Vehicle example,

--- a/lib/state_machine/integrations/active_model/locale.rb
+++ b/lib/state_machine/integrations/active_model/locale.rb
@@ -2,7 +2,6 @@
   :activemodel => {
     :errors => {
       :messages => {
-        :invalid => StateMachine::Machine.default_messages[:invalid],
         :invalid_event => StateMachine::Machine.default_messages[:invalid_event] % ['%{state}'],
         :invalid_transition => StateMachine::Machine.default_messages[:invalid_transition] % ['%{event}']
       }

--- a/lib/state_machine/integrations/active_record.rb
+++ b/lib/state_machine/integrations/active_record.rb
@@ -355,7 +355,6 @@ module StateMachine
     #     activerecord:
     #       errors:
     #         messages:
-    #           invalid: "is invalid"
     #           # %{value} = attribute value, %{state} = Human state name
     #           invalid_event: "cannot transition when %{state}"
     #           # %{value} = attribute value, %{event} = Human event name, %{state} = Human current state name
@@ -371,7 +370,7 @@ module StateMachine
     #       errors:
     #         models:
     #           user:
-    #             invalid: "is not valid"
+    #             invalid_event: "is not valid"
     # 
     # In addition to the above, you can also provide translations for the
     # various states / events in each state machine.  Using the Vehicle example,

--- a/lib/state_machine/integrations/mongo_mapper.rb
+++ b/lib/state_machine/integrations/mongo_mapper.rb
@@ -242,7 +242,6 @@ module StateMachine
     #     mongo_mapper:
     #       errors:
     #         messages:
-    #           invalid: "is invalid"
     #           # %{value} = attribute value, %{state} = Human state name
     #           invalid_event: "cannot transition when %{state}"
     #           # %{value} = attribute value, %{event} = Human event name, %{state} = Human current state name
@@ -255,7 +254,7 @@ module StateMachine
     #       errors:
     #         models:
     #           user:
-    #             invalid: "is not valid"
+    #             invalid_event: "is not valid"
     # 
     # In addition to the above, you can also provide translations for the
     # various states / events in each state machine.  Using the Vehicle example,

--- a/lib/state_machine/integrations/mongoid.rb
+++ b/lib/state_machine/integrations/mongoid.rb
@@ -292,7 +292,6 @@ module StateMachine
     #     mongoid:
     #       errors:
     #         messages:
-    #           invalid: "is invalid"
     #           # %{value} = attribute value, %{state} = Human state name
     #           invalid_event: "cannot transition when %{state}"
     #           # %{value} = attribute value, %{event} = Human event name, %{state} = Human current state name
@@ -305,7 +304,7 @@ module StateMachine
     #       errors:
     #         models:
     #           user:
-    #             invalid: "is not valid"
+    #             invalid_event: "is not valid"
     # 
     # In addition to the above, you can also provide translations for the
     # various states / events in each state machine.  Using the Vehicle example,


### PR DESCRIPTION
Did this in order to avoid overriding user settings for errors.attributes.[name].invalid and errors.messages.invalid as these have a lower priority. Plus, "invalid" already has a default setting (although I don't know how many years ago this made it into the default locale settings).
