### PR TITLE
Remove dependency on the validation_class_methods plugins for Sequel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,8 @@ errors and callbacks.  For example,
 
 ```ruby
 class Vehicle < Sequel::Model
+  plugin :validation_class_methods
+
   state_machine :initial => :parked do
     before_transition :parked => any - :parked, :do => :put_on_seatbelt
     after_transition any => :parked do |transition|

--- a/lib/state_machine/integrations/sequel.rb
+++ b/lib/state_machine/integrations/sequel.rb
@@ -323,7 +323,6 @@ module StateMachine
         
         # Loads all of the Sequel plugins necessary to run
         def load_plugins
-          owner_class.plugin(:validation_class_methods)
           owner_class.plugin(:hook_class_methods)
         end
         


### PR DESCRIPTION
Issue #209. This is to fix problems that occur when someone wants to use ActiveModel validations instead of using the validation_class_methods plugin. Sequel integration should not force usage of this plugin.
