### PR TITLE
Mention common setters like `state_event =`

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,11 @@ out-of-the-box integrations are available for some of the more popular Ruby
 libraries.  These integrations add library-specific behavior, allowing for state
 machines to work more tightly with the conventions defined by those libraries.
 
+One feature they share is the ability to set an `event=` attribute, which
+will cause that transition to happen when an action is fired. For instance,
+`vehicle.state_event = 'ignite'` will not immediately change the vehicle's
+state, but will do so when `save` is called.
+
 The integrations currently available include:
 
 * ActiveModel classes


### PR DESCRIPTION
This feature has been very useful for my team, but we considered it undocumented. I only just realized it is documented in the integration comments and thought it deserved a bit higher billing.

Feel free to put this somewhere else in the README if you'd rather.
