### PR TITLE
Patches file handling to use absolute paths.

### DIFF
--- a/lib/state_machine/integrations/active_record/locale.rb
+++ b/lib/state_machine/integrations/active_record/locale.rb
@@ -1,5 +1,5 @@
 filename = "#{File.dirname(__FILE__)}/../active_model/locale.rb"
-translations = eval(IO.read(filename), binding, filename)
+translations = eval(IO.read(File.expand_path(filename)), binding, filename)
 translations[:en][:activerecord] = translations[:en].delete(:activemodel)
 
 # Only ActiveRecord 2.3.5+ can pull i18n >= 0.1.3 from system-wide gems (and

--- a/lib/state_machine/integrations/mongo_mapper/locale.rb
+++ b/lib/state_machine/integrations/mongo_mapper/locale.rb
@@ -1,4 +1,4 @@
 filename = "#{File.dirname(__FILE__)}/../active_model/locale.rb"
-translations = eval(IO.read(filename), binding, filename)
+translations = eval(IO.read(File.expand_path(filename)), binding, filename)
 translations[:en][:mongo_mapper] = translations[:en].delete(:activemodel)
 translations


### PR DESCRIPTION
We ran in to an issue when we had Ruby packaged in a JAR file under JRuby where files weren't expanded all the way. It's been a little while since I applied the patch, so I don't remember the specifics, but this files like The Right Thing To Do(TM) anyway.
