### PR TITLE
Added state checking at least support - state_from? method

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,26 @@ vehicle.park!                   # => StateMachine::InvalidTransition: Cannot tra
 vehicle.state?(:parked)         # => false
 vehicle.state?(:invalid)        # => IndexError: :invalid is an invalid name
 
+# Check if machine has at least some state
+vehicle.state_from?(:first_gear)    # => true or false
+
+This will return `true` if `vehicle` state is at any of this states:
+
+* first_gear
+* second_gear
+* third_gear
+  
+The `state_from?` will make more sense with linear state machine. For example a state machine for your Order class. Let's consider that your Order has these states:
+
+* pending
+* check_payment
+* paid
+* shipping
+* shipped
+* done
+  
+You need to check if some `@order` has at least 'paid' state. You can easily use: `@order.state_from? :paid`. This will return true only if your `@order` has any of these states: `paid`, `shipping`, `shipped` and `done`.
+
 # Namespaced machines have uniquely-generated methods
 vehicle.alarm_state             # => 1
 vehicle.alarm_state_name        # => :active

--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -1858,7 +1858,19 @@ module StateMachine
     def paths_for(object, requirements = {})
       PathCollection.new(object, self, requirements)
     end
-    
+
+    # Check if some desirable and valid state is between initial and current machine state
+    # This cannot make all's world sense in Vehicle example, but think this state machine
+    #   serving a Order state: I'd like to notify all Orders owners (Customer) who has unless
+    #   paid their order successfully. So, you can: @object.state_from?(:paid). This will
+    #   return true to all states from initial state to paid.
+    #
+    # For example:
+    #   object.state_from?(:paid)  # => true (if object has until paid status (or all before it)) 
+    def state_from_for(object, state)
+      paths_for(object).state_from?(state)
+    end
+
     # Marks the given object as invalid with the given message.
     # 
     # By default, this is a no-op.
@@ -2095,6 +2107,11 @@ module StateMachine
         # Gets the paths of transitions available to the current object
         define_helper(:instance, attribute(:paths)) do |machine, object, *args|
           machine.paths_for(object, *args)
+        end
+
+        # Enable object check if any valid state is between any passed away state
+        define_helper(:instance, attribute("from?".to_sym)) do |machine, object, *args|
+          machine.state_from_for(object, args.first)
         end
       end
       

--- a/lib/state_machine/path_collection.rb
+++ b/lib/state_machine/path_collection.rb
@@ -69,6 +69,25 @@ module StateMachine
     def events
       map {|path| path.events}.flatten.uniq
     end
+
+    # Check if some desirable and valid state is between initial and current machine state
+    # This cannot make all's world sense in Vehicle example, but think this state machine
+    #   serving a Order state: I'd like to notify all Orders owners (Customer) who has unless
+    #   paid their order successfully. So, you can: @object.state_from?(:paid). This will
+    #   return true to all states from initial state to paid.
+    #
+    # For example:
+    #   paths.state_from?(:paid)  # => true (if object has until paid status (or all before it)) 
+    def state_from?(desirable_state_name)
+      return false if @from_name.nil?
+      return true if desirable_state_name.to_sym == @from_name
+
+      all_machine_states = @machine.states.map{|state| state.name}.flatten.uniq.compact
+      return false unless all_machine_states.include? desirable_state_name
+
+      passed_state_index = all_machine_states.index(@from_name)
+      all_machine_states.index(desirable_state_name) <= passed_state_index
+    end
     
     private
       # Gets the initial set of paths to walk

--- a/test/functional/state_machine_test.rb
+++ b/test/functional/state_machine_test.rb
@@ -257,6 +257,10 @@ class VehicleTest < Test::Unit::TestCase
   def test_should_have_human_state_event_names
     assert_equal 'park', Vehicle.human_state_event_name(:park)
   end
+
+  def test_should_have_state_from
+    assert @vehicle.state_from? :parked
+  end
 end
 
 class VehicleUnsavedTest < Test::Unit::TestCase
@@ -453,6 +457,12 @@ class VehicleParkedTest < Test::Unit::TestCase
   
   def test_should_not_allow_park
     assert !@vehicle.park
+  end
+
+  def test_should_state_from_change_after_ignite
+    assert @vehicle.ignite
+    assert @vehicle.state_from? :idling
+    assert @vehicle.state_from? :parked
   end
   
   def test_should_allow_ignite

--- a/test/unit/path_collection_test.rb
+++ b/test/unit/path_collection_test.rb
@@ -31,6 +31,10 @@ class PathCollectionByDefaultTest < Test::Unit::TestCase
   def test_should_have_no_from_states
     assert_equal [], @paths.from_states
   end
+
+  def test_should_have_state_from_as_default_state
+    assert @paths.state_from? :parked
+  end
   
   def test_should_have_no_to_states
     assert_equal [], @paths.to_states
@@ -65,6 +69,11 @@ class PathCollectionTest < Test::Unit::TestCase
   def test_should_raise_exception_if_invalid_to_state_specified
     exception = assert_raise(IndexError) {StateMachine::PathCollection.new(@object, @machine, :to => :invalid)}
     assert_equal ':invalid is an invalid name', exception.message
+  end
+
+  def test_should_return_false_when_invalid_state_specified_to_state_from
+    paths = StateMachine::PathCollection.new(@object, @machine)
+    assert !paths.state_from?(:invalid)
   end
 end
 
@@ -111,6 +120,32 @@ class PathCollectionWithPathsTest < Test::Unit::TestCase
   
   def test_should_have_no_events
     assert_equal [:ignite, :shift_up], @paths.events
+  end
+
+  def test_should_have_state_from_some_state
+    assert @object.ignite
+    assert @object.state_from? :parked
+    assert @object.state_from? :idling
+    assert !@object.state_from?(:first_gear)
+  end
+
+  def test_should_have_state_from_with_any_transition
+    @machine.event :park do
+      transition [:idling, :first_gear] => :parked
+    end
+    
+    @machine.event :ignite do
+      transition :parked => :idling
+    end
+    
+    @machine.event :idle do
+      transition :first_gear => :idling
+    end
+
+    assert @object.ignite
+    assert @object.state_from?(:idling)
+    assert @object.state_from?(:parked)
+    assert !@object.state_from?(:stalled)
   end
 end
 


### PR DESCRIPTION
Hello folks!

I've added a useful resource for "linear based" state machine: an option to check if some object has at least some state.

Motivation:

In one of my needs with state_machine, I'd like to check if my Customer is at least "paid", so, paid or any further states can be valid. Today, I need code something like that:

`if @customer.paid? or @customer.verified? or @customer.authorized?`

Instead, I wanna replace this painful task with something more encapsulated:

`if @customer.state_from?(:paid)`

More simple and readable, right? I've added it to state_machine gem with new unit and functional tests, that validates my code, following the project guidelines. I've updated the Readme.md to explain how to use this new feature.

As I explained in README file, this method is useful with "sequential" state machine. With "Vehicle", could be a little strange (I think, so).

Well. This is my contribution to the project. I read the code a lot before update something and I liked what a read. Very nice project.

If you guys have questions or improvements suggestions, please let me know. This is my first Ruby contribute to opensource. I did it before with PHP projects, but in Ruby is my first try =P

Thanks and keep goin'!
