### PR TITLE
Add disallowing of unwanted helpers

### DIFF
--- a/lib/state_machine/event.rb
+++ b/lib/state_machine/event.rb
@@ -229,23 +229,23 @@ module StateMachine
         # Checks whether the event can be fired on the current object
         machine.define_helper(:instance, "can_#{qualified_name}?") do |machine, object, *args|
           machine.event(name).can_fire?(object, *args)
-        end
-        
+        end unless @machine.disallowed_helpers.include?(:can)
+
         # Gets the next transition that would be performed if the event were
         # fired now
         machine.define_helper(:instance, "#{qualified_name}_transition") do |machine, object, *args|
           machine.event(name).transition_for(object, *args)
-        end
-        
+        end unless @machine.disallowed_helpers.include?(:transition)
+
         # Fires the event
         machine.define_helper(:instance, qualified_name) do |machine, object, *args|
           machine.event(name).fire(object, *args)
-        end
-        
+        end unless @machine.disallowed_helpers.include?(:nonstrict)
+
         # Fires the event, raising an exception if it fails
         machine.define_helper(:instance, "#{qualified_name}!") do |machine, object, *args|
-          object.send(qualified_name, *args) || raise(StateMachine::InvalidTransition.new(object, machine, name))
-        end
+          machine.event(name).fire(object, *args) || raise(StateMachine::InvalidTransition.new(object, machine, name))
+        end unless @machine.disallowed_helpers.include?(:strict)
       end
   end
 end

--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -534,12 +534,16 @@ module StateMachine
     
     # Whether the machine will use transactions when firing events
     attr_reader :use_transactions
-    
+
+    # Which event helpers to disallow. Valid helpers:
+    #   :can, :transition, :nonstrict, :strict
+    attr_reader :disallowed_helpers
+
     # Creates a new state machine for the given attribute
     def initialize(owner_class, *args, &block)
       options = args.last.is_a?(Hash) ? args.pop : {}
-      assert_valid_keys(options, :attribute, :initial, :initialize, :action, :plural, :namespace, :integration, :messages, :use_transactions)
-      
+      assert_valid_keys(options, :attribute, :initial, :initialize, :action, :plural, :namespace, :integration, :messages, :use_transactions, :disallowed_helpers)
+
       # Find an integration that matches this machine's owner class
       if options.include?(:integration)
         @integration = options[:integration] && StateMachine::Integrations.find_by_name(options[:integration])
@@ -566,6 +570,7 @@ module StateMachine
       @action = options[:action]
       @use_transactions = options[:use_transactions]
       @initialize_state = options[:initialize]
+      @disallowed_helpers = options[:disallowed_helpers] || []
       @action_hook_defined = false
       self.owner_class = owner_class
       self.initial_state = options[:initial] unless sibling_machines.any?


### PR DESCRIPTION
In my application, we never want the nonstrict transition method, and want to be sure we never accidentally use it. Any interest in this functionality?
