### PR TITLE
Run all intergration tests if INTEGRATION environment is not set

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ Rake::TestTask.new(:test) do |t|
   integration = %w(active_model active_record data_mapper mongoid mongo_mapper sequel).detect do |name|
     Bundler.default_gemfile.to_s.include?(name)
   end
-  
+
   t.libs << 'lib'
   t.test_files = integration ? Dir["test/unit/integrations/#{integration}_test.rb"] : Dir['test/{functional,unit}/*_test.rb'] + ['test/unit/integrations/base_test.rb']
   t.verbose = true
@@ -25,15 +25,15 @@ end
 namespace :appraisal do
   desc "Run the given task for a particular integration's appraisals"
   task :integration do
-    integration = ENV['INTEGRATION']
-    
+    integration = ENV['INTEGRATION'].to_s
+
     Appraisal::File.each do |appraisal|
       if appraisal.name.include?(integration)
         appraisal.install
         Appraisal::Command.from_args(appraisal.gemfile_path).run
       end
     end
-    
+
     exit
   end
 end


### PR DESCRIPTION
If I try to run `rake appraisal:integration` I have `can't convert nil into String` because INTEGRATION isn't set. I suggest in this case run all integration tests.
