### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# state_machine [![Build Status](https://secure.travis-ci.org/pluginaweek/state_machine.png "Build Status")](http://travis-ci.org/pluginaweek/state_machine) [![Dependency Status](https://gemnasium.com/pluginaweek/state_machine.png "Dependency Status")](https://gemnasium.com/pluginaweek/state_machine)
+# state_machine [![Build Status](https://secure.travis-ci.org/pluginaweek/state_machine.png "Build Status")](http://travis-ci.org/pluginaweek/state_machine) [![Dependency Status](https://gemnasium.com/pluginaweek/state_machine.png "Dependency Status")](https://gemnasium.com/pluginaweek/state_machine) [![Code Climate](https://codeclimate.com/github/pluginaweek/state_machine.png)](https://codeclimate.com/github/pluginaweek/state_machine)
 
 *state_machine* adds support for creating state machines for attributes on any
 Ruby class.


### PR DESCRIPTION
Hello,

It looks like someone (maybe you) added state_machine to Code Climate a while back, and I thought you might want to know.

Code Climate is a tool I built that does automated code reviews for Ruby using static analysis. It's free for OSS, and your metrics live here:

https://codeclimate.com/github/pluginaweek/state_machine

In case you want this information to be available to contributors, this PR just adds a dynamic badge to the README that displays the code quality GPA.

If you have any questions, let me know.

I hope you find Code Climate useful.

Cheers,
Bryan
