### PR TITLE
Added class name to InvalidTransition exception messages.

### DIFF
--- a/lib/state_machine/transition.rb
+++ b/lib/state_machine/transition.rb
@@ -17,7 +17,7 @@ module StateMachine
       @event = machine.events.fetch(event)
       errors = machine.errors_for(object)
       
-      message = "Cannot transition #{machine.name} via :#{self.event} from #{from_name.inspect}"
+      message = "Cannot transition #{object.class.name && object.class.name + ' '}#{machine.name} via :#{self.event} from #{from_name.inspect}"
       message << " (Reason(s): #{errors})" unless errors.empty?
       super(object, message)
     end


### PR DESCRIPTION
I use state_machine with multiple models, and I lost some time chasing a state transition exception coming from a different class than I'd thought. It would be very useful to me to have the class name in that exception message.
