### PR TITLE
Fixed after_transition with mongoid master (4.0)

### DIFF
--- a/lib/state_machine/integrations/mongoid.rb
+++ b/lib/state_machine/integrations/mongoid.rb
@@ -426,6 +426,10 @@ module StateMachine
                 self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
               end
               
+              def update_document(*)
+                self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
+              end              
+              
               def upsert(*)
                 self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
               end


### PR DESCRIPTION
This problem is described in #277
