### PR TITLE
More robust yard handler for transitions

### DIFF
--- a/lib/state_machine/yard/handlers/transition.rb
+++ b/lib/state_machine/yard/handlers/transition.rb
@@ -13,7 +13,7 @@ module StateMachine
             ast = statement.parameters.first
             ast.children.each do |assoc|
               # Skip conditionals
-              next if %w(if unless).include?(assoc[0].jump(:ident).source)
+              next if %w(if :if unless :unless).include?(assoc[0].jump(:ident).source)
               
               options[extract_requirement(assoc[0])] = extract_requirement(assoc[1])
             end


### PR DESCRIPTION
At least in some configurations (always in my case), :if and :unless are read by the transition handler as strings including the colon, which leads to the generation of spurious states in graphviz. This patch fix the problem and is safe (unless somebody wants to have an state called :":unless" :smile: )
