### PR TITLE
Fix `rake state_machine:draw` on namespace collisions 

### DIFF
--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -473,7 +473,13 @@ module StateMachine
           # Navigate through the namespace structure to get to the class
           klass = Object
           class_name.split('::').each do |name|
-            klass = klass.const_defined?(name) ? klass.const_get(name) : klass.const_missing(name)
+            klass_is_defined = begin
+              klass.const_defined?(name, false)
+            rescue
+              # fallback for ruby version < 1.9
+              klass.const_defined?(name)
+            end
+            klass = klass_is_defined ? klass.const_get(name) : klass.const_missing(name)
           end
           
           # Draw each of the class's state machines


### PR DESCRIPTION
This PR fixes a problem of the `state_machine:draw` with namespace collisions.

Given:

```
class User; end # no state_machine
class Admin::User; end #includes state_machine
```

Running  `rake state_machine:draw CLASS=Admin::User` will fail, as class resolves to `User` which doesn't have a statemachine defined.  This PR fixes the klass resolving by disabling inheritance lookup of [`const_defined?`](http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-const_defined-3F). Added a fallback for older ruby version where this feature dosen't exist.
