### PR TITLE
Silence uneccessary warning with default state with value

### DIFF
--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -568,7 +568,6 @@ module StateMachine
       @initialize_state = options[:initialize]
       @action_hook_defined = false
       self.owner_class = owner_class
-      self.initial_state = options[:initial] unless sibling_machines.any?
       
       # Merge with sibling machine configurations
       add_sibling_machine_configs
@@ -580,6 +579,7 @@ module StateMachine
       
       # Evaluate DSL
       instance_eval(&block) if block_given?
+      self.initial_state = options[:initial] unless sibling_machines.any?
     end
     
     # Creates a copy of this machine in addition to copies of each associated

--- a/test/unit/machine_test.rb
+++ b/test/unit/machine_test.rb
@@ -328,6 +328,30 @@ class MachineWithStaticInitialStateTest < Test::Unit::TestCase
   end
 end
 
+class MachineWithInitialStateWithValueAndOwnerDefault < Test::Unit::TestCase
+  def setup
+    @original_stderr, $stderr = $stderr, StringIO.new
+    
+    state_machine_with_defaults = Class.new(StateMachine::Machine) do
+      def owner_class_attribute_default
+        0
+      end
+    end
+    @klass = Class.new
+    @machine = state_machine_with_defaults.new(@klass, :initial => :parked) do
+      state :parked, :value => 0
+    end
+  end
+  
+  def test_should_not_warn_about_wrong_default
+    assert_equal '', $stderr.string
+  end
+  
+  def teardown
+    $stderr = @original_stderr
+  end
+end
+
 class MachineWithDynamicInitialStateTest < Test::Unit::TestCase
   def setup
     @klass = Class.new do


### PR DESCRIPTION
State machine is producing a false positive warnings like this:

```
Both `model class` and its :status machine have defined a different default for "status"
```

It happens with correct machines when states have values and a there is a default value from the schema (or any other integration).

``` ruby
class Request < ActiveRecord::Base
  # schema defines status as an int with default value of 0

  state_machine :status, :initial => :open do
    state :open, :value => 0
    state :closed, :value => 1
  end
end
```

This happens because at the moment of processing the `:initial` argument of the state_machine, the value of `:open` state is unknown (the block hasn't been evaluated yet), state with a default value (the state name) is created and it is compared with default value from schema (0) which produces the warning. Block with the definition of states is processed too late.

This problem can be fixed by setting the initial value as the very last thing that state machine constructor does. This way we can evaluate the block first in order to capture the correct values of states.

I believe this pull request closes: #285 and #279.
