### PR TITLE
ActiveRecord integrations now using transactions respecting "use_transactions" config

### DIFF
--- a/lib/state_machine/integrations/active_record.rb
+++ b/lib/state_machine/integrations/active_record.rb
@@ -525,11 +525,15 @@ module StateMachine
         # an ActiveRecord::Rollback exception if the yielded block fails
         # (i.e. returns false).
         def transaction(object)
-          result = nil
-          object.class.transaction do
-            raise ::ActiveRecord::Rollback unless result = yield
+          if object.class.state_machines[name].use_transactions
+            result = nil
+            object.class.transaction do
+              raise ::ActiveRecord::Rollback unless result = yield
+            end
+            result
+          else
+            yield
           end
-          result
         end
         
         # Defines a new named scope with the given name


### PR DESCRIPTION
Right now state_machine is somewhat abandoned it seems like, given the fact that it is last updated May 2013. 

The bug: https://github.com/pluginaweek/state_machine/issues/264
The fix: https://github.com/pluginaweek/state_machine/pull/255 (included here).
