### PR TITLE
Replace File.exists? with File.exist? to avoid deprecation warning

### DIFF
--- a/lib/state_machine/integrations/base.rb
+++ b/lib/state_machine/integrations/base.rb
@@ -78,7 +78,7 @@ module StateMachine
         # support i18n.
         def locale_path
           path = "#{File.dirname(__FILE__)}/#{integration_name}/locale.rb"
-          path if File.exists?(path)
+          path if File.exist?(path)
         end
         
         # Extends the given object with any version overrides that are currently

--- a/test/unit/machine_test.rb
+++ b/test/unit/machine_test.rb
@@ -3229,26 +3229,26 @@ begin
     
     def test_should_save_file_with_class_name_by_default
       @machine.draw
-      assert File.exists?("./#{@klass.name}_state.png")
+      assert File.exist?("./#{@klass.name}_state.png")
     end
     
     def test_should_allow_base_name_to_be_customized
       name = "machine_#{rand(1000000)}"
       @machine.draw(:name => name)
       @path = "./#{name}.png"
-      assert File.exists?(@path)
+      assert File.exist?(@path)
     end
     
     def test_should_allow_format_to_be_customized
       @machine.draw(:format => 'jpg')
       @path = "./#{@klass.name}_state.jpg"
-      assert File.exists?(@path)
+      assert File.exist?(@path)
     end
     
     def test_should_allow_path_to_be_customized
       @machine.draw(:path => "#{File.dirname(__FILE__)}/")
       @path = "#{File.dirname(__FILE__)}/#{@klass.name}_state.png"
-      assert File.exists?(@path)
+      assert File.exist?(@path)
     end
     
     def test_should_allow_orientation_to_be_landscape


### PR DESCRIPTION
`File.exists?` is a deprecated name in the latest MRI `ruby-2.1.2` - see it on [ruby-doc](http://www.ruby-doc.org/core-2.1.2/File.html#method-c-exists-3F)

I started getting the warning with `ruby-2.1.0`. Here it is:

```
gems/state_machine-1.2.0/lib/state_machine/integrations/base.rb:81: warning: File.exists? is a deprecated name, use File.exist? instead
```
