### PR TITLE
Only load Sequel's inflector as a last resort

### DIFF
--- a/lib/state_machine/integrations/sequel.rb
+++ b/lib/state_machine/integrations/sequel.rb
@@ -310,8 +310,14 @@ module StateMachine
       
       # Pluralizes the name using the built-in inflector
       def pluralize(word)
-        load_inflector
-        super
+        word = word.to_s
+
+        if word.respond_to?(:pluralize)
+          word.pluralize
+        else
+          load_inflector
+          super
+        end
       end
       
       protected


### PR DESCRIPTION
It monkey-patches String thus breaking our app:

Before adding state_machine gem: 'filter_metadata'.pluralize => 'filter_metadata'
After adding state_machine gem: 'filter_metadata'.pluralize => 'filter_metadatas'
