### PR TITLE
Include object class in state machine transition error

### DIFF
--- a/lib/state_machine/transition.rb
+++ b/lib/state_machine/transition.rb
@@ -16,9 +16,10 @@ module StateMachine
       @from = machine.read(object, :state)
       @event = machine.events.fetch(event)
       errors = machine.errors_for(object)
-      
+
       message = "Cannot transition #{machine.name} via :#{self.event} from #{from_name.inspect}"
       message << " (Reason(s): #{errors})" unless errors.empty?
+      message << " (Object class): #{object.class.name}"
       super(object, message)
     end
     

--- a/test/unit/invalid_transition_test.rb
+++ b/test/unit/invalid_transition_test.rb
@@ -42,7 +42,7 @@ class InvalidTransitionTest < Test::Unit::TestCase
   end
   
   def test_should_generate_a_message
-    assert_equal 'Cannot transition state via :ignite from :parked', @invalid_transition.message
+    assert_match 'Cannot transition state via :ignite from :parked', @invalid_transition.message
   end
 end
 
@@ -100,13 +100,13 @@ class InvalidTransitionWithIntegrationTest < Test::Unit::TestCase
   def test_should_generate_a_message_without_reasons_if_empty
     @object.errors = ''
     invalid_transition = StateMachine::InvalidTransition.new(@object, @machine, :ignite)
-    assert_equal 'Cannot transition state via :ignite from :parked', invalid_transition.message
+    assert_match 'Cannot transition state via :ignite from :parked', invalid_transition.message
   end
   
   def test_should_generate_a_message_with_error_reasons_if_errors_found
     @object.errors = 'Id is invalid, Name is invalid'
     invalid_transition = StateMachine::InvalidTransition.new(@object, @machine, :ignite)
-    assert_equal 'Cannot transition state via :ignite from :parked (Reason(s): Id is invalid, Name is invalid)', invalid_transition.message
+    assert_match 'Cannot transition state via :ignite from :parked (Reason(s): Id is invalid, Name is invalid)', invalid_transition.message
   end
   
   def teardown


### PR DESCRIPTION
In our project we have a lot of related objects with state machine. And it's rather hard to figure out which object has incorrect state with a message like this:

"Cannot transition status via :to_completed from :provisioning (Reason(s): status is invalid". The Pull Request is proposal to add the object class to the message to make it more informative.
