### PR TITLE
StateMachine::Machine.silence_method_conflicts

### DIFF
--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -496,6 +496,10 @@ module StateMachine
     # get generated for a machine's owner class.  Default is false.
     class << self; attr_accessor :ignore_method_conflicts; end
     @ignore_method_conflicts = false
+
+    # Weather to silence the warning for method conflicts
+    class << self; attr_accessor :silence_method_conflicts; end
+    @silence_method_conflicts = false
     
     # The class that the machine is defined in
     attr_reader :owner_class
@@ -757,7 +761,7 @@ module StateMachine
       if block_given?
         if !self.class.ignore_method_conflicts && conflicting_ancestor = owner_class_ancestor_has_method?(scope, method)
           ancestor_name = conflicting_ancestor.name && !conflicting_ancestor.name.empty? ? conflicting_ancestor.name : conflicting_ancestor.to_s
-          warn "#{scope == :class ? 'Class' : 'Instance'} method \"#{method}\" is already defined in #{ancestor_name}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true."
+          warn "#{scope == :class ? 'Class' : 'Instance'} method \"#{method}\" is already defined in #{ancestor_name}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message." unless self.class.silence_method_conflicts
         else
           name = self.name
           helper_module.class_eval do

--- a/test/unit/event_test.rb
+++ b/test/unit/event_test.rb
@@ -173,7 +173,7 @@ class EventWithConflictingHelpersBeforeDefinitionTest < Test::Unit::TestCase
   
   def test_should_output_warning
     expected = %w(can_ignite? ignite_transition ignite ignite!).map do |method|
-      "Instance method \"#{method}\" is already defined in #{@superclass.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.\n"
+      "Instance method \"#{method}\" is already defined in #{@superclass.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message.\n"
     end.join
     
     assert_equal expected, $stderr.string

--- a/test/unit/machine_test.rb
+++ b/test/unit/machine_test.rb
@@ -1152,7 +1152,7 @@ class MachineWithInstanceHelpersTest < Test::Unit::TestCase
     machine = StateMachine::Machine.new(klass)
     
     machine.define_helper(:instance, :park) {}
-    assert_equal "Instance method \"park\" is already defined in #{superclass.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    assert_equal "Instance method \"park\" is already defined in #{superclass.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -1173,7 +1173,7 @@ class MachineWithInstanceHelpersTest < Test::Unit::TestCase
     machine = StateMachine::Machine.new(klass)
     
     machine.define_helper(:instance, :park) {}
-    assert_equal "Instance method \"park\" is already defined in #{superclass1.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    assert_equal "Instance method \"park\" is already defined in #{superclass1.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -1192,7 +1192,7 @@ class MachineWithInstanceHelpersTest < Test::Unit::TestCase
     machine = StateMachine::Machine.new(klass)
     
     machine.define_helper(:instance, :park) {}
-    assert_equal "Instance method \"park\" is already defined in #{mod.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    assert_equal "Instance method \"park\" is already defined in #{mod.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -1238,6 +1238,44 @@ class MachineWithInstanceHelpersTest < Test::Unit::TestCase
     $stderr = @original_stderr
   end
   
+  def test_should_not_warn_if_silencing_method_conflicts
+    require 'stringio'
+    @original_stderr, $stderr = $stderr, StringIO.new
+    StateMachine::Machine.silence_method_conflicts = true
+    
+    superclass = Class.new do
+      def park
+      end
+    end
+    klass = Class.new(superclass)
+    machine = StateMachine::Machine.new(klass)
+    
+    machine.define_helper(:instance, :park) {true}
+    assert_equal '', $stderr.string
+  ensure
+    StateMachine::Machine.silence_method_conflicts = false
+    $stderr = @original_stderr
+  end
+
+  def test_should_not_override_method_if_only_silencing_method_conflicts
+    require 'stringio'
+    @original_stderr, $stderr = $stderr, StringIO.new
+    StateMachine::Machine.silence_method_conflicts = true
+    
+    superclass = Class.new do
+      def park
+      end
+    end
+    klass = Class.new(superclass)
+    machine = StateMachine::Machine.new(klass)
+    
+    machine.define_helper(:instance, :park) {true}
+    assert_equal nil, klass.new.park
+  ensure
+    StateMachine::Machine.silence_method_conflicts = false
+    $stderr = @original_stderr
+  end
+  
   def test_should_define_nonexistent_methods
     @machine.define_helper(:instance, :park) {false}
     assert_equal false, @object.park
@@ -1250,7 +1288,7 @@ class MachineWithInstanceHelpersTest < Test::Unit::TestCase
     @machine.define_helper(:instance, :park) {}
     @machine.define_helper(:instance, :park) {}
     
-    assert_equal "Instance method \"park\" is already defined in #{@klass} :state instance helpers, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    assert_equal "Instance method \"park\" is already defined in #{@klass} :state instance helpers, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -1334,7 +1372,7 @@ class MachineWithClassHelpersTest < Test::Unit::TestCase
     machine = StateMachine::Machine.new(klass)
     
     machine.define_helper(:class, :park) {}
-    assert_equal "Class method \"park\" is already defined in #{superclass.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    assert_equal "Class method \"park\" is already defined in #{superclass.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -1355,7 +1393,7 @@ class MachineWithClassHelpersTest < Test::Unit::TestCase
     machine = StateMachine::Machine.new(klass)
     
     machine.define_helper(:class, :park) {}
-    assert_equal "Class method \"park\" is already defined in #{superclass1.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    assert_equal "Class method \"park\" is already defined in #{superclass1.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -1374,7 +1412,7 @@ class MachineWithClassHelpersTest < Test::Unit::TestCase
     machine = StateMachine::Machine.new(klass)
     
     machine.define_helper(:class, :park) {}
-    assert_equal "Class method \"park\" is already defined in #{mod.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    assert_equal "Class method \"park\" is already defined in #{mod.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -1432,7 +1470,7 @@ class MachineWithClassHelpersTest < Test::Unit::TestCase
     @machine.define_helper(:class, :states) {}
     @machine.define_helper(:class, :states) {}
     
-    assert_equal "Class method \"states\" is already defined in #{@klass} :state class helpers, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    assert_equal "Class method \"states\" is already defined in #{@klass} :state class helpers, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -1626,7 +1664,7 @@ class MachineWithConflictingHelpersBeforeDefinitionTest < Test::Unit::TestCase
       'Class method "with_states"',
       'Class method "without_state"',
       'Class method "without_states"'
-    ].map {|method| "#{method} is already defined in #{@superclass.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.\n"}.join
+    ].map {|method| "#{method} is already defined in #{@superclass.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message.\n"}.join
     
     assert_equal expected, $stderr.string
   end

--- a/test/unit/state_test.rb
+++ b/test/unit/state_test.rb
@@ -503,7 +503,7 @@ class StateWithConflictingHelpersBeforeDefinitionTest < Test::Unit::TestCase
   end
   
   def test_should_output_warning
-    assert_equal "Instance method \"parked?\" is already defined in #{@superclass.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    assert_equal "Instance method \"parked?\" is already defined in #{@superclass.to_s}, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message.\n", $stderr.string
   end
   
   def teardown
@@ -596,7 +596,7 @@ class StateWithConflictingMachineNameTest < Test::Unit::TestCase
   
   def test_should_output_warning_if_name_conflicts
     StateMachine::State.new(@state_machine, :state)
-    assert_equal "Instance method \"state?\" is already defined in #{@klass} :state instance helpers, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    assert_equal "Instance method \"state?\" is already defined in #{@klass} :state instance helpers, use generic helper instead or set StateMachine::Machine.ignore_method_conflicts = true. Set StateMachine::Machine.silence_method_conflicts to suppress this warning message.\n", $stderr.string
   end
   
   def teardown


### PR DESCRIPTION
Add the ability to silence the warning message when states and class methods conflict, without overriding the methods on the superclass.

We have a couple old state machines which, quite unwisely, conflict with ActiveRecord method names. While there are long term plans to fix them, it'd be quite nice to clear the noise in the meantime
