### PR TITLE
hack for state_machine/rails-4.2 compatibility

### DIFF
--- a/lib/state_machine/integrations/active_record.rb
+++ b/lib/state_machine/integrations/active_record.rb
@@ -454,7 +454,7 @@ module StateMachine
           # can be overridden for a new object *prior* to the processing of the
           # attributes passed into #initialize
           define_helper :class, <<-end_eval, __FILE__, __LINE__ + 1
-            def column_defaults(*) #:nodoc:
+            def default_attributes(*) #:nodoc:
               result = super
               # No need to pass in an object, since the overrides will be forced
               self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => result)

--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -701,8 +701,8 @@ module StateMachine
       if state && (options[:force] || initialize_state?(object))
         value = state.value
         
-        if hash = options[:to]
-          hash[attribute.to_s] = value
+        if attribute_set = options[:to]
+          attribute_set.write_from_user(attribute.to_s, value)
         else
           write(object, :state, value)
         end


### PR DESCRIPTION
state_machine overrides `column_defaults` but as of rails 4.2 it
needs to override `default_attributes` to get the same behaviour.

Ideally we need to figure a less hacky / dangerous way to set default
initial states for the machine.

current rails edge / rails 4.1.6:

https://github.com/rails/rails/blob/c4767e13d4ae927e6d605cad3846c9807745b883/activerecord/lib/active_record/core.rb#L264
https://github.com/rails/rails/blob/v4.1.6/activerecord/lib/active_record/core.rb#L186

ps. putting this out there just in case someone else notice the issue and need a fix or perhaps even figure a much better solution (given this project is no longer maintained)
