### PR TITLE
Activerecord 4.2 upgrade

### DIFF
--- a/lib/state_machine/integrations/active_record.rb
+++ b/lib/state_machine/integrations/active_record.rb
@@ -440,35 +440,12 @@ module StateMachine
           end
         end
         
-        # Defines an initialization hook into the owner class for setting the
-        # initial state of the machine *before* any attributes are set on the
-        # object
-        def define_state_initializer
-          define_static_state_initializer
-          define_dynamic_state_initializer
-        end
-        
-        # Initializes static states
-        def define_static_state_initializer
-          # This is the only available hook where the default set of attributes
-          # can be overridden for a new object *prior* to the processing of the
-          # attributes passed into #initialize
-          define_helper :class, <<-end_eval, __FILE__, __LINE__ + 1
-            def default_attributes(*) #:nodoc:
-              result = super
-              # No need to pass in an object, since the overrides will be forced
-              self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => result)
-              result
-            end
-          end_eval
-        end
-        
         # Initializes dynamic states
-        def define_dynamic_state_initializer
+        def define_state_initializer
           define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
-            def initialize(*)
-              super do |*args|
-                self.class.state_machines.initialize_states(self, :static => false)
+            def initialize(attributes = nil, options = {})
+              super(attributes, options) do |*args|
+                self.class.state_machines.initialize_states self
                 yield(*args) if block_given?
               end
             end

--- a/lib/state_machine/integrations/active_record.rb
+++ b/lib/state_machine/integrations/active_record.rb
@@ -454,7 +454,7 @@ module StateMachine
           # can be overridden for a new object *prior* to the processing of the
           # attributes passed into #initialize
           define_helper :class, <<-end_eval, __FILE__, __LINE__ + 1
-            def column_defaults(*) #:nodoc:
+            def default_attributes(*) #:nodoc:
               result = super
               # No need to pass in an object, since the overrides will be forced
               self.state_machines.initialize_states(nil, :static => :force, :dynamic => false, :to => result)

--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -701,8 +701,8 @@ module StateMachine
       if state && (options[:force] || initialize_state?(object))
         value = state.value
         
-        if hash = options[:to]
-          hash[attribute.to_s] = value
+        if attribute_set = options[:to]
+          attribute_set.write_from_user(attribute.to_s, value)
         else
           write(object, :state, value)
         end

--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -700,12 +700,7 @@ module StateMachine
       state = initial_state(object)
       if state && (options[:force] || initialize_state?(object))
         value = state.value
-        
-        if attribute_set = options[:to]
-          attribute_set.write_from_user(attribute.to_s, value)
-        else
-          write(object, :state, value)
-        end
+        object.send "#{attribute}=", value
       end
     end
     
@@ -1982,17 +1977,6 @@ module StateMachine
         define_path_helpers
         define_action_helpers if define_action_helpers?
         define_name_helpers
-      end
-      
-      # Defines the initial values for state machine attributes.  Static values
-      # are set prior to the original initialize method and dynamic values are
-      # set *after* the initialize method in case it is dependent on it.
-      def define_state_initializer
-        define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
-          def initialize(*)
-            self.class.state_machines.initialize_states(self) { super }
-          end
-        end_eval
       end
       
       # Adds reader/writer methods for accessing the state attribute

--- a/lib/state_machine/machine_collection.rb
+++ b/lib/state_machine/machine_collection.rb
@@ -24,20 +24,8 @@ module StateMachine
     # * <tt>:to</tt> - A hash to write the initialized state to instead of
     #   writing to the object.  Default is to write directly to the object.
     def initialize_states(object, options = {})
-      assert_valid_keys(options, :static, :dynamic, :to)
-      options = {:static => true, :dynamic => true}.merge(options)
-      
-      each_value do |machine| 
-        machine.initialize_state(object, :force => options[:static] == :force, :to => options[:to]) unless machine.dynamic_initial_state?
-      end if options[:static]
-      
-      result = yield if block_given?
-      
-      each_value do |machine|
-        machine.initialize_state(object, :force => options[:dynamic] == :force, :to => options[:to]) if machine.dynamic_initial_state?
-      end if options[:dynamic]
-      
-      result
+      options = { :force => false }.merge(options)
+      each_value { |machine| machine.initialize_state object, options }
     end
     
     # Runs one or more events in parallel on the given object.  See


### PR DESCRIPTION
Work on making this gem compatible with activerecord 4.2. Worked on this a while ago but I still would like to drop mongoid and datamapper support and release it as a new gem.
