### PR TITLE
Add license to gemspec

### DIFF
--- a/state_machine.gemspec
+++ b/state_machine.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.test_files        = s.files.grep(/^test\//)
   s.rdoc_options      = %w(--line-numbers --inline-source --title state_machine --main README.md)
   s.extra_rdoc_files  = %w(README.md CHANGELOG.md LICENSE)
+  s.license           = 'MIT'
   
   s.add_development_dependency("rake")
   s.add_development_dependency("simplecov")


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
