### PR TITLE
Add extra debug information to a transition

### DIFF
--- a/lib/state_machine/branch.rb
+++ b/lib/state_machine/branch.rb
@@ -29,9 +29,14 @@ module StateMachine
     # * +from+ / +except_from+
     # * +to+ / +except_to+
     attr_reader :known_states
-    
+
+    # Line where transition was defined
+    attr_reader :transition_defined_in
+
     # Creates a new branch
     def initialize(options = {}) #:nodoc:
+      @transition_defined_in = options.delete(:transition_defined_in)
+
       # Build conditionals
       @if_condition = options.delete(:if)
       @unless_condition = options.delete(:unless)

--- a/lib/state_machine/event.rb
+++ b/lib/state_machine/event.rb
@@ -108,7 +108,9 @@ module StateMachine
       # Only a certain subset of explicit options are allowed for transition
       # requirements
       assert_valid_keys(options, :from, :to, :except_from, :except_to, :if, :unless) if (options.keys - [:from, :to, :on, :except_from, :except_to, :except_on, :if, :unless]).empty?
-      
+
+      options[:transition_defined_in] = caller[0]
+
       branches << branch = Branch.new(options.merge(:on => name))
       @known_states |= branch.known_states
       branch
@@ -151,8 +153,8 @@ module StateMachine
             
             match[:to].filter(values).first
           end
-          
-          return Transition.new(object, machine, name, from, to, !custom_from_state)
+
+          return Transition.new(object, machine, name, from, to, !custom_from_state, branch)
         end
       end
       

--- a/lib/state_machine/transition.rb
+++ b/lib/state_machine/transition.rb
@@ -83,7 +83,10 @@ module StateMachine
     
     # Whether the transition is only existing temporarily for the object
     attr_writer :transient
-    
+
+    # The branch that caused this transition
+    attr_reader :branch
+
     # Determines whether the curreny ruby implementation supports pausing and
     # resuming transitions
     def self.pause_supported?
@@ -91,7 +94,7 @@ module StateMachine
     end
     
     # Creates a new, specific transition
-    def initialize(object, machine, event, from_name, to_name, read_state = true) #:nodoc:
+    def initialize(object, machine, event, from_name, to_name, read_state = true, branch = nil) #:nodoc:
       @object = object
       @machine = machine
       @args = []
@@ -103,7 +106,9 @@ module StateMachine
       @from = read_state ? machine.read(object, :state) : @from_state.value
       @to_state = machine.states.fetch(to_name)
       @to = @to_state.value
-      
+
+      @branch = branch
+
       reset
     end
     


### PR DESCRIPTION
The transition is now tagged with the branched that caused it, and the branch
itself is now tagged with the line that defined it.
