### PR TITLE
sequel integration fix

### DIFF
--- a/lib/state_machine/integrations/sequel.rb
+++ b/lib/state_machine/integrations/sequel.rb
@@ -422,7 +422,7 @@ module StateMachine
         
         # Uses the DB literal to match the default against the specified state
         def owner_class_attribute_default_matches?(state)
-          owner_class.db.literal(state.value) == owner_class_attribute_default
+          state.value == owner_class_attribute_default
         end
         
         # Creates a scope for finding records *with* a particular state or

--- a/lib/state_machine/integrations/sequel.rb
+++ b/lib/state_machine/integrations/sequel.rb
@@ -416,7 +416,7 @@ module StateMachine
         # Gets the db default for the machine's attribute
         def owner_class_attribute_default
           if owner_class.db.table_exists?(owner_class.table_name) && column = owner_class.db_schema[attribute.to_sym]
-            column[:default]
+            column[:ruby_default]
           end
         end
         


### PR DESCRIPTION
fixing fetching default state from db column (:de…fault is db, :ruby_default is ruby)

This was generating an unnecessary warning. This is because sequel (I don't know since when, but long ago) loads column info defaults in db format and ruby format 
