### PR TITLE
Add link to ActiveRecord integration file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ end
 ```
 
 For more information about the various behaviors added for ActiveRecord state
-machines, see `StateMachine::Integrations::ActiveRecord`.
+machines, see [`StateMachine::Integrations::ActiveRecord`](lib/state_machine/integrations/active_record.rb).
 
 ### DataMapper
 


### PR DESCRIPTION
Useful since much of the AR documentation is in the code documentation.