### PR TITLE
After [this commit](https://github.com/rails/rails/blob/c9c293e19464c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Raise InvalidContext error when the current state does not define a state-driven behavior
 * Fix target state being indeterminate for transitions that use blacklists
 * Allow super to be called within state-driven behaviors
+* Fix issue with Rails 6.1+ where ActiveRecord.column_defaults returns `frozen` hash
 
 ## 1.2.0 / 2013-03-30
 

--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -701,7 +701,7 @@ module StateMachine
       if state && (options[:force] || initialize_state?(object))
         value = state.value
         
-        if hash = options[:to]
+        if hash = options[:to].dup
           hash[attribute.to_s] = value
         else
           write(object, :state, value)


### PR DESCRIPTION
After [this commit](https://github.com/rails/rails/blob/c9c293e19464c9ce37316f2d917ac123d7b654e6/activerecord/lib/active_record/model_schema.rb#L395) `ActiveRecord.column_defaults` returns frozen hash and this behaviour brakes the state machine `initialize_state` method. This PR fixes the issue.